### PR TITLE
Memory leak fix for LightningEditor

### DIFF
--- a/LightningCore/Renderer/Metal/MetalFrameBuffer.cpp
+++ b/LightningCore/Renderer/Metal/MetalFrameBuffer.cpp
@@ -39,8 +39,6 @@ MetalFrameBuffer::~MetalFrameBuffer()
     if (m_DepthTexture)
         m_DepthTexture->release();
     
-    if (m_DepthTextureDescriptor)
-        m_DepthTextureDescriptor->release();
  
 }
 
@@ -78,7 +76,15 @@ void MetalFrameBuffer::Create(float p_Width, float p_Height)
     m_DepthAttachmentDescriptor->setClearDepth(1.0);
     m_DepthAttachmentDescriptor->setStoreAction(MTL::StoreActionDontCare);
     
-    m_TextureDescriptor->release();
+    
+    if (m_DepthTextureDescriptor)
+    {
+        m_DepthTextureDescriptor->release();
+    }
+    if (m_TextureDescriptor)
+    {
+        m_TextureDescriptor->release();
+    }
 
 }
 

--- a/premake5.lua
+++ b/premake5.lua
@@ -186,8 +186,10 @@ project "LightningCore"
 		systemversion "latest"
 		cppdialect "C++23"
 		staticruntime "On"
-
+    
     filter "system:macosx"
+     buildoptions  { "-std=c++23", "-fobjc-arc" }
+
         xcodebuildsettings {
             ["SKIP_INSTALL"] = "YES",
             ["ENABLE_BITCODE"] = "NO",


### PR DESCRIPTION
Enable ARC is needed for ImGui when using Metal Backend (Link: https://github.com/ocornut/imgui/pull/8565). Additional leaks came from not releasing m_DepthTextureDescriptor in Create() function. Now it passes all memory leak checks in XCode.